### PR TITLE
Deal with mirrored & rotated tiles

### DIFF
--- a/1_scrape.js
+++ b/1_scrape.js
@@ -255,9 +255,56 @@ async function generateScreenshot(baseUrl, data) {
 				if (!tileIndex) return;
 
 				// Read out the flags
-				let flipped_horizontally = (tileIndex & FLIPPED_HORIZONTALLY_FLAG);
-				let flipped_vertically = (tileIndex & FLIPPED_VERTICALLY_FLAG);
-				let flipped_diagonally = (tileIndex & FLIPPED_DIAGONALLY_FLAG);
+				let flipped_horizontally = Boolean(tileIndex & FLIPPED_HORIZONTALLY_FLAG);
+				let flipped_vertically = Boolean(tileIndex & FLIPPED_VERTICALLY_FLAG);
+				let flipped_diagonally = Boolean(tileIndex & FLIPPED_DIAGONALLY_FLAG);
+
+				// https://github.com/photonstorm/phaser/blob/master/src/tilemaps/parsers/tiled/ParseGID.js
+				// https://github.com/photonstorm/phaser/blob/master/src/tilemaps/parsers/tiled/ParseTileLayers.js
+				// https://github.com/photonstorm/phaser/blob/master/src/tilemaps/TilemapLayerCanvasRenderer.js
+				let rotation = 0;
+				let flipped = false;
+
+				if (flipped_horizontally && flipped_vertically && flipped_diagonally)
+				{
+					rotation = Math.PI / 2;
+					flipped = true;
+				}
+				else if (flipped_horizontally && flipped_vertically && !flipped_diagonally)
+				{
+					rotation = Math.PI;
+					flipped = false;
+				}
+				else if (flipped_horizontally && !flipped_vertically && flipped_diagonally)
+				{
+					rotation = Math.PI / 2;
+					flipped = false;
+				}
+				else if (flipped_horizontally && !flipped_vertically && !flipped_diagonally)
+				{
+					rotation = 0;
+					flipped = true;
+				}
+				else if (!flipped_horizontally && flipped_vertically && flipped_diagonally)
+				{
+					rotation = 3 * Math.PI / 2;
+					flipped = false;
+				}
+				else if (!flipped_horizontally && flipped_vertically && !flipped_diagonally)
+				{
+					rotation = Math.PI;
+					flipped = true;
+				}
+				else if (!flipped_horizontally && !flipped_vertically && flipped_diagonally)
+				{
+					rotation = 3 * Math.PI / 2;
+					flipped = true;
+				}
+				else if (!flipped_horizontally && !flipped_vertically && !flipped_diagonally)
+				{
+					rotation = 0;
+					flipped = false;
+				}
 
 				// Clear the flags
 				tileIndex &= ~(FLIPPED_HORIZONTALLY_FLAG |
@@ -267,8 +314,22 @@ async function generateScreenshot(baseUrl, data) {
 				let tile = tiles[tileIndex];
 				if (!tile) return;
 				if (!tile.image) return;
+
+				ctx.save();
+
+				let halfWidth = tile.w / 2;
+				let halfHeight = tile.h / 2;
+
+				ctx.translate(x0*32 + halfWidth, y0*32 + halfHeight);
+
+				let h_scale = flipped ? -1 : 1;
+
+				ctx.scale(h_scale,1);
+				ctx.rotate(rotation);
+
 				ctx.globalAlpha = l.opacity;
-				ctx.drawImage(tile.image, tile.x, tile.y, tile.w, tile.h, x0*32, y0*32, 32, 32);
+				ctx.drawImage(tile.image, tile.x, tile.y, tile.w, tile.h, -halfWidth, -halfHeight, tile.w, tile.h);
+				ctx.restore();
 			})
 		}
 	}

--- a/1_scrape.js
+++ b/1_scrape.js
@@ -11,6 +11,10 @@ const {Image, createCanvas} = require('canvas');
 const cacheFetch = new Cache(resolve(__dirname, 'cache'));
 const imageFetch = new Cache(resolve(__dirname, 'image'));
 
+const FLIPPED_HORIZONTALLY_FLAG = 0x80000000;
+const FLIPPED_VERTICALLY_FLAG   = 0x40000000;
+const FLIPPED_DIAGONALLY_FLAG   = 0x20000000;
+
 let queue = new Queue();
 queue.add('https://lobby.maps.at.rc3.world/main.json');
 
@@ -249,6 +253,17 @@ async function generateScreenshot(baseUrl, data) {
 			visibleLayers.forEach(l => {
 				let tileIndex = l.data[index];
 				if (!tileIndex) return;
+
+				// Read out the flags
+				let flipped_horizontally = (tileIndex & FLIPPED_HORIZONTALLY_FLAG);
+				let flipped_vertically = (tileIndex & FLIPPED_VERTICALLY_FLAG);
+				let flipped_diagonally = (tileIndex & FLIPPED_DIAGONALLY_FLAG);
+
+				// Clear the flags
+				tileIndex &= ~(FLIPPED_HORIZONTALLY_FLAG |
+								FLIPPED_VERTICALLY_FLAG |
+								FLIPPED_DIAGONALLY_FLAG);
+
 				let tile = tiles[tileIndex];
 				if (!tile) return;
 				if (!tile.image) return;


### PR DESCRIPTION
Mirroring and rotation is stored in the highest 3 bits of the Tile ID in the layer. This peace of code should make that work with the screenshot generation as well.